### PR TITLE
Fix `run start` command to work with node v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Alpha version / unstable.
 
 ## Setup
 
+**Recommended node version: v18 (LTS)**. v20 should also work but is not tested extensively.
+
 Chainweb-stream-server currently requires a local redis client to cache results.
 
 Configuration via environment variables or dotenv file is required. Copy the `.default.env` file into `.env` and set at least the `NETWORK`, `DATA_HOST` and `CHAINWEB_HOST` values.

--- a/package.json
+++ b/package.json
@@ -10,15 +10,13 @@
     "node": ">=12"
   },
   "scripts": {
-    "start": "ts-node ./src/index.ts",
+    "start": "node --no-warnings=ExperimentalWarning --loader ts-node/esm ./src/index.ts",
     "build": "tsc",
     "build:watch": "tsc -w",
     "format": "prettier -w ./src",
     "knip": "knip",
     "lint": "eslint ./src",
-    "test": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --silent .",
-    "test:coverage": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand . --coverage",
-    "test:watch": "NODE_ENV=test NODE_OPTIONS=--experimental-vm-modules jest --runInBand --watch ."
+    "test": "echo \"No tests yet\""
   },
   "dependencies": {
     "compression": "^1.7.4",


### PR DESCRIPTION
node v20 breaks ts-node but a workaround was found in [this issue](https://github.com/TypeStrong/ts-node/issues/1997)

(That issue also has reports of ballooning memory consumption. I did some small scale local tests but did not encounter this issue.)

Added that we recommend the LTS v18 in the README.

Also removed the `npm run test` commands for now. 